### PR TITLE
Manually call workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -25,5 +25,6 @@ jobs:
           git tag $TAG
           git push origin $TAG
           gh release create $TAG
+          gh workflow run goreleaser.yml --ref $TAG
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the tag pushed is not able to trigger [the goreleaser.yml workflow](https://github.com/LibOps/homebrew-cli/blob/main/.github/workflows/goreleaser.yml) call it manually.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow