### PR TITLE
Fix bug detecting region

### DIFF
--- a/pkg/gcloud/run.go
+++ b/pkg/gcloud/run.go
@@ -18,6 +18,10 @@ func GetCloudRunUrl(p, env string) (string, error) {
                 }
 	}
 	region := os.Getenv("LIBOPS_REGION")
+	if region == "" {
+		region = "us-central1"
+	}
+	
 
 	args := []string{
 		"run",
@@ -34,7 +38,7 @@ func GetCloudRunUrl(p, env string) (string, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		log.Println("Failed to location remote service")
+		log.Println("Failed to locate remote service")
 		return "", err
 	}
 


### PR DESCRIPTION
When dotenv loads OK, and `LIBOPS_REGION` isn't set, we need to provide a default.